### PR TITLE
Incorporate HandValidator into Tile Interactions

### DIFF
--- a/src/modules/game/Timer/Timer.ts
+++ b/src/modules/game/Timer/Timer.ts
@@ -1,0 +1,57 @@
+import * as PIXI from 'pixi.js';
+import { PIXI_TEXT_STYLE } from '../../../pixi/mahjongConstants';
+
+class Timer {
+  private isRunning: boolean;
+
+  private timeStart: number;
+
+  // milliseconds
+  private timeToRun: number;
+
+  private container: PIXI.Container;
+
+  constructor() {
+    this.isRunning = false;
+    this.timeStart = 0;
+    this.timeToRun = 0;
+    this.container = new PIXI.Container();
+  }
+
+  public getIsRunning(): boolean {
+    return this.isRunning;
+  }
+
+  public getContainer(): PIXI.Container {
+    return this.container;
+  }
+
+  public startTimer(currentTime: number, timeToRun: number): void {
+    this.timeStart = currentTime;
+    this.timeToRun = timeToRun;
+    this.isRunning = true;
+  }
+
+  public removeAllAssets(): void {
+    this.container.removeChildren(0, this.container.children.length);
+  }
+
+  public render(): void {
+    if (!this.isRunning) {
+      return;
+    }
+
+    const timeNow = new Date().getTime();
+
+    const timeLeft = Math.round((this.timeStart + this.timeToRun - timeNow) / 1000);
+    if (timeLeft > 0) {
+      const text = new PIXI.Text(timeLeft.toString(), PIXI_TEXT_STYLE);
+      this.container.addChild(text);
+      this.container.y = 200;
+    } else {
+      this.isRunning = false;
+    }
+  }
+}
+
+export default Timer;

--- a/src/modules/game/Timer/Timer.ts
+++ b/src/modules/game/Timer/Timer.ts
@@ -2,12 +2,18 @@ import * as PIXI from 'pixi.js';
 import { PIXI_TEXT_STYLE } from '../../../pixi/mahjongConstants';
 
 class Timer {
+  static defaultCallback = (): void => {
+    console.log('Timer ended!');
+  };
+
   private isRunning: boolean;
 
   private timeStart: number;
 
   // milliseconds
   private timeToRun: number;
+
+  private callback = Timer.defaultCallback;
 
   private container: PIXI.Container;
 
@@ -16,6 +22,14 @@ class Timer {
     this.timeStart = 0;
     this.timeToRun = 0;
     this.container = new PIXI.Container();
+  }
+
+  public setCallback(callback: () => void): void {
+    this.callback = callback;
+  }
+
+  public getCallback(): () => void {
+    return this.callback;
   }
 
   public getIsRunning(): boolean {
@@ -32,23 +46,27 @@ class Timer {
     this.isRunning = true;
   }
 
+  public stopTimer(): void {
+    this.isRunning = false;
+    this.callback = Timer.defaultCallback;
+  }
+
   public removeAllAssets(): void {
     this.container.removeChildren(0, this.container.children.length);
   }
 
-  public render(): void {
+  public update(): void {
     if (!this.isRunning) {
       return;
     }
 
     const timeNow = new Date().getTime();
-
     const timeLeft = Math.round((this.timeStart + this.timeToRun - timeNow) / 1000);
     if (timeLeft > 0) {
       const text = new PIXI.Text(timeLeft.toString(), PIXI_TEXT_STYLE);
       this.container.addChild(text);
-      this.container.y = 200;
     } else {
+      this.callback();
       this.isRunning = false;
     }
   }

--- a/src/modules/game/Timer/test/Timer.test.ts
+++ b/src/modules/game/Timer/test/Timer.test.ts
@@ -27,10 +27,25 @@ test('Timer - startTimer()', () => {
   expect(timer.getIsRunning()).toBeTruthy();
 });
 
-test('Timer - render()', () => {
+test('Timer - update()', () => {
   timer.startTimer(new Date().getTime(), 1000);
   timer.update();
   expect(timer.getContainer().children).toHaveLength(1);
   timer.removeAllAssets();
   expect(timer.getContainer().children).toHaveLength(0);
+});
+
+test('Timer - update() timeout', async () => {
+  timer.startTimer(new Date().getTime(), 100);
+  timer.update();
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  timer.update();
+  expect(timer.getIsRunning()).toBeFalsy();
+});
+
+test('Timer - update() does not update', async () => {
+  timer.startTimer(new Date().getTime(), 100);
+  timer.stopTimer();
+  timer.update();
+  expect(timer.getIsRunning()).toBeFalsy();
 });

--- a/src/modules/game/Timer/test/Timer.test.ts
+++ b/src/modules/game/Timer/test/Timer.test.ts
@@ -1,0 +1,36 @@
+import 'jest-webgl-canvas-mock';
+import Timer from '../Timer';
+
+let timer: Timer;
+
+const dummyCallback = () => {};
+
+beforeEach(() => {
+  timer = new Timer();
+});
+
+test('Timer - setCallback()', () => {
+  timer.setCallback(dummyCallback);
+  expect(timer.getCallback()).toEqual(dummyCallback);
+});
+
+test('Timer - getIsRunning()', () => {
+  expect(timer.getIsRunning()).toBeFalsy();
+});
+
+test('Timer - getContainer()', () => {
+  expect(timer.getContainer().children).toHaveLength(0);
+});
+
+test('Timer - startTimer()', () => {
+  timer.startTimer(new Date().getTime(), 1000);
+  expect(timer.getIsRunning()).toBeTruthy();
+});
+
+test('Timer - render()', () => {
+  timer.startTimer(new Date().getTime(), 1000);
+  timer.update();
+  expect(timer.getContainer().children).toHaveLength(1);
+  timer.removeAllAssets();
+  expect(timer.getContainer().children).toHaveLength(0);
+});

--- a/src/modules/mahjong/DeadPile/DeadPile.ts
+++ b/src/modules/mahjong/DeadPile/DeadPile.ts
@@ -62,12 +62,8 @@ class DeadPile {
   /**
    * Removes the last tile from the deadpile
    */
-  public removeLastTile(): boolean {
-    if (this.deadpile.length > 0) {
-      this.deadpile.pop();
-      return true;
-    }
-    return false;
+  public removeLastTile(): Tile | undefined {
+    return this.deadpile.pop();
   }
 
   /**

--- a/src/modules/mahjong/Hand/PlayerHand.ts
+++ b/src/modules/mahjong/Hand/PlayerHand.ts
@@ -21,7 +21,7 @@ class PlayerHand {
 
   private madeMeld: boolean;
 
-  // TODO: add boolean to say concealed
+  private concealed: boolean;
 
   // For hand validation
   private wind: WindEnums;
@@ -36,6 +36,7 @@ class PlayerHand {
     this.madeMeld = false;
     this.wind = WindEnums.EAST;
     this.flowerNumber = 1;
+    this.concealed = true;
   }
 
   /**
@@ -127,6 +128,10 @@ class PlayerHand {
     return this.wind;
   }
 
+  public getConcealed(): boolean {
+    return this.concealed;
+  }
+
   /**
    * Return boolean of whether the hand can play tile
    */
@@ -161,6 +166,10 @@ class PlayerHand {
   public addPlayedTiles(tiles: Tile[]): boolean {
     // could add validation that this is valid meld
     this.playedTiles.push(tiles);
+
+    if (tiles.length >= 3) {
+      this.concealed = false;
+    }
     return true;
   }
 
@@ -220,6 +229,10 @@ class PlayerHand {
 
   public sortHand(weights: SortHandWeights): void {
     this.tiles = sortHandUtils(this.tiles, weights);
+  }
+
+  public getAllTiles(): Tile[] {
+    return [...this.tiles, ...this.playedTiles.flat()];
   }
 }
 

--- a/src/modules/mahjong/Hand/PlayerHand.ts
+++ b/src/modules/mahjong/Hand/PlayerHand.ts
@@ -21,6 +21,8 @@ class PlayerHand {
 
   private madeMeld: boolean;
 
+  // TODO: add boolean to say concealed
+
   // For hand validation
   private wind: WindEnums;
 

--- a/src/modules/mahjong/Hand/PlayerHand.ts
+++ b/src/modules/mahjong/Hand/PlayerHand.ts
@@ -162,6 +162,21 @@ class PlayerHand {
     return true;
   }
 
+  public removeTiles(tiles: Tile[]): boolean {
+    const numOfTilesToRemove = tiles.length;
+    const numOfHandTiles = this.tiles.length;
+    tiles.forEach((tile) => {
+      const indexToSplice = this.tiles.findIndex((handTile) => tile.toString() === handTile.toString());
+      if (indexToSplice !== -1) {
+        this.tiles.splice(indexToSplice, 1);
+      } else {
+        console.error('Tile not found in hand. Could not remove in removeTiles()');
+      }
+    });
+
+    return this.tiles.length === numOfHandTiles - numOfTilesToRemove;
+  }
+
   public getSelectedTile(): number {
     return this.selectedTile;
   }

--- a/src/modules/mahjong/Hand/test/PlayerHand.test.ts
+++ b/src/modules/mahjong/Hand/test/PlayerHand.test.ts
@@ -95,6 +95,11 @@ test('PlayerHand - draw()', () => {
   expect(fullHand.getTiles()).toStrictEqual(tiles);
 });
 
+test('PlayerHand - draw() - cannot draw', () => {
+  fullHand.setMadeMeld(true);
+  expect(fullHand.draw(TileFactory.createTileFromStringDef('7_DOT'))).toBeFalsy();
+});
+
 test('PlayerHand - getFlowerNumber()', () => {
   expect(emptyHand.getFlowerNumber()).toBe(1);
   expect(fullHand.getFlowerNumber()).toBe(1);
@@ -128,4 +133,15 @@ test('PlayerHand - setWind()', () => {
   expect(emptyHand.getWind()).toBe(WindEnums.NORTH);
   expect(emptyHand.setWind('SOMETHING' as WindEnums)).toBeFalsy();
   expect(emptyHand.getWind()).toBe(WindEnums.NORTH);
+});
+
+test('PlayerHand - removeTiles()', () => {
+  const tilesToRemove = [TileFactory.createTileFromStringDef('8_DOT'), TileFactory.createTileFromStringDef('8_DOT')];
+  expect(fullHand.removeTiles(tilesToRemove)).toBeTruthy();
+  expect(fullHand.getTiles()).toHaveLength(11);
+});
+
+test('PlayerHand - removeTiles() - bad request', () => {
+  const tilesToRemove = [TileFactory.createTileFromStringDef('8_DOT'), TileFactory.createTileFromStringDef('9_DOT')];
+  expect(fullHand.removeTiles(tilesToRemove)).toBeFalsy();
 });

--- a/src/modules/mahjong/HandValidator/HandValidator.ts
+++ b/src/modules/mahjong/HandValidator/HandValidator.ts
@@ -2,7 +2,7 @@
  * Class to store logic related to validating a Mahjong Hand
  */
 import Tile from '../Tile/Tile';
-// eslint-disable-next-line prettier/prettier
+// eslint-disable-next-line
 import {
   ValidPair,
   Meld,

--- a/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
+++ b/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
@@ -7,6 +7,7 @@ import SpriteFactory from '../../../pixi/SpriteFactory';
 import DeadPile from '../DeadPile/DeadPile';
 import WallCounter from '../WallCounter/WallCounter';
 import { OutgoingAction } from '../../ws';
+// eslint-disable-next-line import/no-cycle
 import MahjongPlayer from '../MahjongPlayer/MahjongPlayer';
 import MahjongOpponent from '../MahjongOpponent/MahjongOpponent';
 
@@ -126,11 +127,9 @@ class MahjongGameState extends GameState {
     const indexOfUser = gameUsers.findIndex((user) => user.getConnectionId() === this.mjPlayer.getConnectionId());
     if (indexOfUser === this.dealer) {
       // Draw tile if player is the dealer
-      console.log('player dealer');
       this.wsCallbacks[OutgoingAction.DRAW_TILE]();
     } else {
       // Opponent draws tile
-      console.log('opponent dealer');
       const opponent = gameUsers[this.dealer] as MahjongOpponent;
       opponent.drawTile();
     }
@@ -189,9 +188,8 @@ class MahjongGameState extends GameState {
         user.render(spriteFactory, stage, isUserTurn, this.wsCallbacks);
         user.reposition(view);
       });
-      const deadPileTiles = this.deadPile.getDeadPile();
 
-      this.mjPlayer.renderInteractions(spriteFactory, this.wsCallbacks, deadPileTiles);
+      this.mjPlayer.renderInteractions(spriteFactory, this.wsCallbacks, this);
 
       // Render Wall
       this.wallCounter.removeAllAssets();

--- a/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
+++ b/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
@@ -201,7 +201,13 @@ class MahjongGameState extends GameState {
         (user) => user.getConnectionId() === this.mjPlayer.getConnectionId(),
       );
       const canCreateConsecutive = playerIndex === (this.getCurrentTurn() + 1) % 4;
-      this.mjPlayer.renderInteractions(spriteFactory, this.wsCallbacks, deadPileTiles, canCreateConsecutive);
+      this.mjPlayer.renderInteractions(
+        spriteFactory,
+        this.wsCallbacks,
+        deadPileTiles,
+        canCreateConsecutive,
+        this.getCurrentWind(),
+      );
 
       if (this.mjPlayer.getAllowInteraction()) {
         const timer = this.mjPlayer.getTimer().getContainer();

--- a/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
+++ b/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
@@ -116,6 +116,10 @@ class MahjongGameState extends GameState {
     return this.mjPlayer;
   }
 
+  public getWallCounter(): WallCounter {
+    return this.wallCounter;
+  }
+
   public startRound(): boolean {
     this.roundStarted = true;
     const gameUsers = super.getUsers();
@@ -183,6 +187,10 @@ class MahjongGameState extends GameState {
         user.render(spriteFactory, stage, isUserTurn, this.wsCallbacks);
         user.reposition(view);
       });
+      const deadPileTiles = this.deadPile.getDeadPile();
+
+      this.mjPlayer.renderInteractions(spriteFactory, this.wsCallbacks, deadPileTiles);
+
       // Render Wall
       this.wallCounter.removeAllAssets();
       this.wallCounter.render(spriteFactory, stage);

--- a/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
+++ b/src/modules/mahjong/MahjongGameState/MahjongGameState.ts
@@ -126,9 +126,11 @@ class MahjongGameState extends GameState {
     const indexOfUser = gameUsers.findIndex((user) => user.getConnectionId() === this.mjPlayer.getConnectionId());
     if (indexOfUser === this.dealer) {
       // Draw tile if player is the dealer
+      console.log('player dealer');
       this.wsCallbacks[OutgoingAction.DRAW_TILE]();
     } else {
       // Opponent draws tile
+      console.log('opponent dealer');
       const opponent = gameUsers[this.dealer] as MahjongOpponent;
       opponent.drawTile();
     }

--- a/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
+++ b/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
@@ -120,3 +120,17 @@ test('MahjongGameState - setTurn()', () => {
   gameState.setTurn(1);
   expect(gameState.getCurrentTurn()).toBe(1);
 });
+
+test('MahjongGameState - update()', () => {
+  mjPlayer.setAllowInteraction(true);
+  const timer = mjPlayer.getTimer();
+  expect(timer.getContainer().children).toHaveLength(0); // timer hasn't started
+});
+
+test('MahjongGameState - renderCanvas() -include timer', () => {
+  mjPlayer.setAllowInteraction(true);
+  gameState.renderCanvas(spriteFactory, pixiApp);
+  expect(pixiApp.stage.children).toHaveLength(7); // 4 - users, 1 deadpile, 1 wall, 1 timer
+  gameState.requestRedraw();
+  expect(pixiApp.stage.children).toHaveLength(7);
+});

--- a/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
+++ b/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
@@ -14,7 +14,9 @@ let mjOpponent1: MahjongOpponent;
 let mjOpponent2: MahjongOpponent;
 let mjOpponent3: MahjongOpponent;
 let gameState: MahjongGameState;
+let gameStateOne: MahjongGameState;
 let users: UserEntity[];
+let usersOpponentFirst: UserEntity[];
 const PLAYER_NAME = 'Jay Chou';
 
 let pixiApp: PIXI.Application;
@@ -27,12 +29,14 @@ const callbacks = {
 
 beforeEach(() => {
   mjPlayer = new MahjongPlayer(PLAYER_NAME, 'connectionId');
-  mjOpponent1 = new MahjongOpponent('Opp Left', 'connectionId', RenderDirection.LEFT);
-  mjOpponent2 = new MahjongOpponent('Opp Top', 'connectionId', RenderDirection.TOP);
-  mjOpponent3 = new MahjongOpponent('Opp Right', 'connectionId', RenderDirection.RIGHT);
+  mjOpponent1 = new MahjongOpponent('Opp Left', 'connectionId1', RenderDirection.LEFT);
+  mjOpponent2 = new MahjongOpponent('Opp Top', 'connectionId2', RenderDirection.TOP);
+  mjOpponent3 = new MahjongOpponent('Opp Right', 'connectionId3', RenderDirection.RIGHT);
   users = [mjPlayer, mjOpponent1, mjOpponent2, mjOpponent3];
+  usersOpponentFirst = [mjOpponent1, mjPlayer, mjOpponent2, mjOpponent3];
 
   gameState = new MahjongGameState(users, mjPlayer, callbacks);
+  gameStateOne = new MahjongGameState(usersOpponentFirst, mjPlayer, callbacks);
 
   pixiApp = { stage: new PIXI.Container(), view: {} as HTMLCanvasElement }; // mocking
 });
@@ -55,6 +59,17 @@ test('MahjongGameState - roundStarted()', () => {
   expect(gameState.getRoundStarted()).toBeTruthy();
   gameState.endRound();
   expect(gameState.getRoundStarted()).toBeFalsy();
+});
+
+test('MahjongGameState - roundStarted() - opponent first', () => {
+  expect(gameStateOne.getRoundStarted()).toBeFalsy();
+  gameStateOne.startRound();
+  expect(gameStateOne.getRoundStarted()).toBeTruthy();
+  expect(mjOpponent1.getHand().getHasDrawn()).toBeTruthy();
+});
+
+test('MahjongGameState - getWallCounter()', () => {
+  expect(gameState.getWallCounter().getContainer().children).toHaveLength(0);
 });
 
 test('MahjongGameState - getDealer() / changeDealer()', () => {

--- a/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
+++ b/src/modules/mahjong/MahjongGameState/test/MahjongGameState.test.ts
@@ -125,6 +125,8 @@ test('MahjongGameState - update()', () => {
   mjPlayer.setAllowInteraction(true);
   const timer = mjPlayer.getTimer();
   expect(timer.getContainer().children).toHaveLength(0); // timer hasn't started
+  gameState.update();
+  expect(timer.getContainer().children).toHaveLength(0); // timer hasn't started
 });
 
 test('MahjongGameState - renderCanvas() -include timer', () => {

--- a/src/modules/mahjong/MahjongOpponent/MahjongOpponent.ts
+++ b/src/modules/mahjong/MahjongOpponent/MahjongOpponent.ts
@@ -56,7 +56,6 @@ class MahjongOpponent extends UserEntity {
 
   /**
    * Returns a PIXI.Container containing all back tile sprites
-   * TODO: render played tiles
    * @param spriteFactory SpriteFactory
    */
   public renderMahjongHand(spriteFactory: SpriteFactory): PIXI.Container {

--- a/src/modules/mahjong/MahjongOpponent/test/MahjongOpponent.test.ts
+++ b/src/modules/mahjong/MahjongOpponent/test/MahjongOpponent.test.ts
@@ -62,6 +62,12 @@ test('MahjongOpponent - renderMahjongHand()', () => {
   expect(hand.children).toHaveLength(14); // 13 tiles and 1 container for playedTiles
 });
 
+test('MahjongOpponent - renderMahjongHand() and drawn', () => {
+  mjOpponent.drawTile();
+  const hand = mjOpponent.renderMahjongHand(spriteFactory);
+  expect(hand.children).toHaveLength(15); // 14 tiles and 1 container for playedTiles
+});
+
 test('MahjongOpponent - renderMahjongHand() with playedTiles', () => {
   mjOpponent.addPlayedTiles(SAMPLE_TILE_ARRAY);
   let hand = mjOpponent.renderMahjongHand(spriteFactory);
@@ -125,4 +131,16 @@ test('MahjongOpponent - reposition() / render()', () => {
   expect(mjOpponent.getContainer().y).toBe(80);
   mjOpponent.render(spriteFactory, pixiStage, false);
   expect(mjOpponent.getContainer().children).toHaveLength(2);
+});
+
+test('MahjongOpponent - setHasDrawn()', () => {
+  expect(mjOpponent.getHand().getHasDrawn()).toBeFalsy();
+  mjOpponent.drawTile();
+  expect(mjOpponent.getHand().getHasDrawn()).toBeTruthy();
+});
+
+test('MahjongOpponent - playedTile()', () => {
+  mjOpponent.drawTile();
+  mjOpponent.playedTile();
+  expect(mjOpponent.getHand().getHasDrawn()).toBeFalsy();
 });

--- a/src/modules/mahjong/MahjongPlayer/MahjongPlayer.ts
+++ b/src/modules/mahjong/MahjongPlayer/MahjongPlayer.ts
@@ -242,6 +242,7 @@ class MahjongPlayer extends UserEntity {
         if (this.allowInteraction) {
           this.setAllowInteraction(false);
           callbacks[OutgoingAction.PLAYED_TILE_INTERACTION](payload);
+          this.timer.stopTimer();
         }
         callbacks.REQUEST_REDRAW();
       });
@@ -308,6 +309,7 @@ class MahjongPlayer extends UserEntity {
       if (this.allowInteraction) {
         this.setAllowInteraction(false);
         callbacks[OutgoingAction.PLAYED_TILE_INTERACTION](payload);
+        this.timer.stopTimer();
       }
       callbacks.REQUEST_REDRAW();
     });

--- a/src/modules/mahjong/MahjongPlayer/MahjongPlayer.ts
+++ b/src/modules/mahjong/MahjongPlayer/MahjongPlayer.ts
@@ -18,6 +18,9 @@ import Tile from '../Tile/Tile';
 import { OutgoingAction } from '../../ws';
 import WindEnums from '../enums/WindEnums';
 import HandValidator from '../HandValidator/HandValidator';
+// import Timer from '../../game/Timer/Timer';
+// eslint-disable-next-line import/no-cycle
+import MahjongGameState from '../MahjongGameState/MahjongGameState';
 
 const PLAY_TILE_TEXT = 'PLAY_TILE';
 const SKIP_TEXT = 'SKIP';
@@ -29,6 +32,8 @@ const WAITING_TEXT = 'Waiting for others...';
 class MahjongPlayer extends UserEntity {
   private hand: PlayerHand;
 
+  // private timer: Timer;
+
   private allowInteraction: boolean;
 
   private interactionContainer: PIXI.Container;
@@ -38,6 +43,7 @@ class MahjongPlayer extends UserEntity {
     this.hand = new PlayerHand();
     this.allowInteraction = false;
     this.interactionContainer = new PIXI.Container();
+    // this.timer = new Timer();
   }
 
   public getHand(): PlayerHand {
@@ -180,7 +186,7 @@ class MahjongPlayer extends UserEntity {
   public renderInteractions(
     spriteFactory: SpriteFactory,
     callbacks: Record<string, (...args: unknown[]) => void>,
-    deadPileTiles: Tile[],
+    gameState: MahjongGameState,
   ): void {
     console.log(spriteFactory);
     const container = new PIXI.Container();
@@ -199,10 +205,17 @@ class MahjongPlayer extends UserEntity {
       });
     }
 
+    const deadPileTiles = gameState.getDeadPile().getDeadPile();
+    const currentTurn = gameState.getCurrentTurn();
+    const playerIndex = gameState.getUsers().findIndex((user) => user.getConnectionId() === this.getConnectionId());
+    const canCreateConsecutive = playerIndex === (currentTurn + 1) % 4;
+    console.log(canCreateConsecutive);
+
     // Render interaction buttons when player is prompted to.
     if (this.allowInteraction && deadPileTiles.length > 0) {
       const hand = this.hand.getTiles();
       const playedTile = deadPileTiles[deadPileTiles.length - 1];
+      // TODO: add in boolean to canCreateMeld to take into account for consecutive
       const results = HandValidator.canCreateMeld(hand, playedTile);
       console.log(results);
       const { quad, triplet, consecutive } = results;

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -8,6 +8,7 @@ import TileFactory from '../../Tile/TileFactory';
 import Tile from '../../Tile/Tile';
 import WindEnums from '../../enums/WindEnums';
 import DeadPile from '../../DeadPile/DeadPile';
+import { OutgoingAction } from '../../../ws';
 
 const { JSDOM } = jsdom;
 const dom = new JSDOM();
@@ -35,7 +36,10 @@ const tile8 = TileFactory.createTileFromStringDef('8_DOT');
 let deadPile: DeadPile;
 
 const spriteFactory = new SpriteFactory({});
-const callbacks = {};
+const callbacks = {
+  [OutgoingAction.PLAYED_TILE_INTERACTION]: () => console.log('played tile callback'),
+  REQUEST_REDRAW: () => console.log('redraw callback'),
+};
 let pixiStage: PIXI.Container;
 
 const NAME = 'Jay Chou';
@@ -192,6 +196,16 @@ test('MahjongPlayer - renderInteraction() with deadpile', () => {
 
   mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
+});
+
+test('MahjongPlayer - renderInteraction() with deadpile and skip', () => {
+  deadPile.add(tile);
+  mjPlayer.setHand(tiles);
+  mjPlayer.setAllowInteraction(true);
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
+
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(0); // nothing to render
 });
 
 test('MahjongPlayer - renderInteraction() with other parameters', () => {

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -31,7 +31,8 @@ const tileStrings = [
 
 let tiles: Tile[];
 const tile = TileFactory.createTileFromStringDef('1_DOT');
-const deadPile = new DeadPile();
+const tile8 = TileFactory.createTileFromStringDef('8_DOT');
+let deadPile: DeadPile;
 
 const spriteFactory = new SpriteFactory({});
 const callbacks = {};
@@ -48,6 +49,7 @@ const SAMPLE_TILE_ARRAY = [
 
 beforeEach(() => {
   tiles = tileStrings.map((t) => TileFactory.createTileFromStringDef(t));
+  deadPile = new DeadPile();
   mjPlayer = new MahjongPlayer(NAME, 'ASDF');
   pixiStage = new PIXI.Container();
 });
@@ -176,6 +178,16 @@ test('MahjongPlayer - getAllowInteraction()', () => {
 });
 
 test('MahjongPlayer - renderInteraction()', () => {
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
+
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
+});
+
+test('MahjongPlayer - renderInteraction() with deadpile', () => {
+  deadPile.add(tile8);
+  mjPlayer.setHand(tiles);
+  mjPlayer.setAllowInteraction(true);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
   mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -257,3 +257,19 @@ test('MahjongPlayer - canWin selfdrawn + renderInteraction()', () => {
   mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });
+
+test('MahjongPlayer - renderInteractionsWithPlayedTiles()', () => {
+  const container = new PIXI.Container();
+  mjPlayer.setAllowInteraction(true);
+  mjPlayer.setHand(winnableTiles);
+  deadPile.add(tile8);
+  mjPlayer.renderInteractionsWithPlayedTile(
+    spriteFactory,
+    callbacks,
+    deadPile.getDeadPile(),
+    false,
+    WindEnums.EAST,
+    container,
+  );
+  expect(container.children).toHaveLength(1);
+});

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -30,6 +30,23 @@ const tileStrings = [
   'WHITEDRAGON',
 ];
 
+const winnableTileStrings = [
+  '7_DOT',
+  '7_DOT',
+  '7_DOT',
+  '8_DOT',
+  '8_DOT',
+  '2_BAMBOO',
+  '2_BAMBOO',
+  '2_BAMBOO',
+  '9_CHARACTER',
+  '9_CHARACTER',
+  '9_CHARACTER',
+  'NORTH',
+  'NORTH',
+];
+const winnableTiles = winnableTileStrings.map((tile) => TileFactory.createTileFromStringDef(tile));
+
 let tiles: Tile[];
 const tile = TileFactory.createTileFromStringDef('1_DOT');
 const tile8 = TileFactory.createTileFromStringDef('8_DOT');
@@ -194,7 +211,7 @@ test('MahjongPlayer - renderInteraction() with deadpile', () => {
   mjPlayer.setAllowInteraction(true);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });
 
@@ -204,7 +221,7 @@ test('MahjongPlayer - renderInteraction() with deadpile and skip', () => {
   mjPlayer.setAllowInteraction(true);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0); // nothing to render
 });
 
@@ -212,12 +229,31 @@ test('MahjongPlayer - renderInteraction() with other parameters', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
   mjPlayer.setAllowInteraction(true);
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 
   mjPlayer.removeAllAssets();
   mjPlayer.setAllowInteraction(false);
   mjPlayer.getHand().draw(tile);
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
+});
+
+test('MahjongPlayer - getTimer()', () => {
+  const timer = mjPlayer.getTimer();
+  expect(timer.getIsRunning()).toBeFalsy();
+});
+
+test('MahjongPlayer - canWin + renderInteraction()', () => {
+  mjPlayer.setHand(winnableTiles);
+  deadPile.add(tile8);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
+});
+
+test('MahjongPlayer - canWin selfdrawn + renderInteraction()', () => {
+  mjPlayer.setHand(winnableTiles);
+  mjPlayer.addTileToHand(tile8);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -201,7 +201,7 @@ test('MahjongPlayer - getAllowInteraction()', () => {
 test('MahjongPlayer - renderInteraction()', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });
 
@@ -222,7 +222,7 @@ test('MahjongPlayer - renderInteraction() with deadpile and skip', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
   mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false, WindEnums.EAST);
-  expect(mjPlayer.getInteractionContainer().children).toHaveLength(0); // nothing to render
+  expect(mjPlayer.getInteractionContainer().children).toHaveLength(1); // empty container
 });
 
 test('MahjongPlayer - renderInteraction() with other parameters', () => {

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -204,7 +204,7 @@ test('MahjongPlayer - renderInteraction() with deadpile and skip', () => {
   mjPlayer.setAllowInteraction(true);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0); // nothing to render
 });
 
@@ -212,12 +212,12 @@ test('MahjongPlayer - renderInteraction() with other parameters', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
   mjPlayer.setAllowInteraction(true);
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 
   mjPlayer.removeAllAssets();
   mjPlayer.setAllowInteraction(false);
   mjPlayer.getHand().draw(tile);
-  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile(), false);
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });

--- a/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
+++ b/src/modules/mahjong/MahjongPlayer/test/MahjongPlayer.test.ts
@@ -7,6 +7,7 @@ import SpriteFactory from '../../../../pixi/SpriteFactory';
 import TileFactory from '../../Tile/TileFactory';
 import Tile from '../../Tile/Tile';
 import WindEnums from '../../enums/WindEnums';
+import DeadPile from '../../DeadPile/DeadPile';
 
 const { JSDOM } = jsdom;
 const dom = new JSDOM();
@@ -30,6 +31,7 @@ const tileStrings = [
 
 let tiles: Tile[];
 const tile = TileFactory.createTileFromStringDef('1_DOT');
+const deadPile = new DeadPile();
 
 const spriteFactory = new SpriteFactory({});
 const callbacks = {};
@@ -176,7 +178,7 @@ test('MahjongPlayer - getAllowInteraction()', () => {
 test('MahjongPlayer - renderInteraction()', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
-  mjPlayer.renderInteractions(spriteFactory, callbacks);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });
 
@@ -184,12 +186,12 @@ test('MahjongPlayer - renderInteraction() with other parameters', () => {
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(0);
 
   mjPlayer.setAllowInteraction(true);
-  mjPlayer.renderInteractions(spriteFactory, callbacks);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 
   mjPlayer.removeAllAssets();
   mjPlayer.setAllowInteraction(false);
   mjPlayer.getHand().draw(tile);
-  mjPlayer.renderInteractions(spriteFactory, callbacks);
+  mjPlayer.renderInteractions(spriteFactory, callbacks, deadPile.getDeadPile());
   expect(mjPlayer.getInteractionContainer().children).toHaveLength(1);
 });

--- a/src/modules/mahjong/enums/MeldEnums.ts
+++ b/src/modules/mahjong/enums/MeldEnums.ts
@@ -2,6 +2,7 @@ enum MeldTypes {
   TRIPLET = 'TRIPLET',
   CONSECUTIVE = 'CONSECUTIVE',
   QUAD = 'QUAD',
+  WIN = 'WIN',
 }
 
 export default MeldTypes;

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -252,6 +252,8 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
       }
     } else {
       const { connectionId, playedTiles, meldType } = data;
+      // Remove last tile from deadpile
+      const playedTile = mjGameState.getDeadPile().removeLastTile();
 
       if (connectionId && playedTiles && meldType) {
         const tiles = playedTiles.map((tileStr) => TileFactory.createTileFromStringDef(tileStr));
@@ -260,7 +262,14 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
           // Player updates their PlayedTiles
           mjPlayer.getHand().addPlayedTiles(tiles);
 
-          // TODO (NextPR): remove played tiles from player hand
+          const indexOfPlayedTile = tiles.findIndex((tile) => playedTile?.toString() === tile.toString());
+          if (indexOfPlayedTile !== -1) {
+            const tilesToRemove = [...tiles];
+            tilesToRemove.splice(indexOfPlayedTile, 1);
+            mjPlayer.getHand().removeTiles(tilesToRemove);
+          } else {
+            console.error('Hand state error, could not remove tiles');
+          }
 
           mjPlayer.getHand().setMadeMeld(true);
         } else {
@@ -271,8 +280,6 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
         // Set turn to the person who interacted successfully
         mjGameState.setTurn(userIndex);
       }
-      // Remove last tile from deadpile
-      mjGameState.getDeadPile().removeLastTile();
     }
 
     mjGameState.requestRedraw();

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -211,7 +211,7 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
         mjPlayer.setAllowInteraction(false);
         wsCallbacks.REQUEST_REDRAW();
       });
-      timer.startTimer(new Date().getTime(), 5000);
+      timer.startTimer(new Date().getTime(), 7500);
     } else {
       // TODO (NextPR): Display msg to player who played tile to wait while others make decision
     }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -198,7 +198,6 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
       }
 
       mjPlayer.setAllowInteraction(true);
-      // TODO: (NextPR) set timeout, if nothing happens, send skip
     } else {
       // TODO (NextPR): Display msg to player who played tile to wait while others make decision
     }
@@ -236,6 +235,9 @@ const GamePage = ({ ws, currentUser }: GameProps): JSX.Element => {
     if (data.skipInteraction) {
       // If everybody skips, game can proceed normally
       mjGameState.goToNextTurn();
+
+      // Increase wall counter
+      mjGameState.getWallCounter().increaseCounter();
 
       const userIndex = mjGameState.getCurrentTurn();
       const currentUserEntity = mjGameState.getUsers()[userIndex];

--- a/src/pages/GameTest.tsx
+++ b/src/pages/GameTest.tsx
@@ -17,6 +17,7 @@ import UserEntity from '../modules/game/UserEntity/UserEntity';
 import Interactions from '../pixi/Interactions';
 import HongKongWall from '../modules/mahjong/Wall/version/HongKongWall';
 import Tile from '../modules/mahjong/Tile/Tile';
+import Timer from '../modules/game/Timer/Timer';
 
 /**
  * ********************************************************
@@ -73,6 +74,9 @@ let player: UserEntity;
 const wall = new HongKongWall();
 const playedTilesOne = ['1_DOT', '1_DOT', '1_DOT'].map((tile) => TileFactory.createTileFromStringDef(tile));
 const playedTilesTwo = ['4_DOT', '5_DOT', '6_DOT'].map((tile) => TileFactory.createTileFromStringDef(tile));
+
+const timer = new Timer();
+timer.startTimer(new Date().getTime(), 10000);
 
 /**
  * Testing page for the Game.
@@ -162,6 +166,11 @@ const GameTestPage = (): JSX.Element => {
     });
     stage.addChild(drawText);
     stage.addChild(nextTurnText);
+
+    timer.removeAllAssets();
+    timer.render();
+    const con = timer.getContainer();
+    stage.addChild(con);
   };
 
   /**

--- a/src/pages/GameTest.tsx
+++ b/src/pages/GameTest.tsx
@@ -17,7 +17,7 @@ import UserEntity from '../modules/game/UserEntity/UserEntity';
 import Interactions from '../pixi/Interactions';
 import HongKongWall from '../modules/mahjong/Wall/version/HongKongWall';
 import Tile from '../modules/mahjong/Tile/Tile';
-import Timer from '../modules/game/Timer/Timer';
+// import Timer from '../modules/game/Timer/Timer';
 
 /**
  * ********************************************************
@@ -75,8 +75,8 @@ const wall = new HongKongWall();
 const playedTilesOne = ['1_DOT', '1_DOT', '1_DOT'].map((tile) => TileFactory.createTileFromStringDef(tile));
 const playedTilesTwo = ['4_DOT', '5_DOT', '6_DOT'].map((tile) => TileFactory.createTileFromStringDef(tile));
 
-const timer = new Timer();
-timer.startTimer(new Date().getTime(), 10000);
+// const timer = new Timer();
+// timer.startTimer(new Date().getTime(), 10000);
 
 /**
  * Testing page for the Game.
@@ -142,7 +142,12 @@ const GameTestPage = (): JSX.Element => {
     opponentTest.addPlayedTiles(playedTilesTwo);
 
     gameState = new MahjongGameState(allUserEntities, mahjongPlayer, mockWSCallbacks);
-    console.log(gameState);
+    const mj = gameState as MahjongGameState;
+    mj.getMjPlayer().setAllowInteraction(true);
+
+    const timer = mj.getMjPlayer().getTimer();
+
+    timer.startTimer(new Date().getTime(), 5000);
   };
 
   const forGameTesting = () => {
@@ -166,11 +171,6 @@ const GameTestPage = (): JSX.Element => {
     });
     stage.addChild(drawText);
     stage.addChild(nextTurnText);
-
-    timer.removeAllAssets();
-    timer.render();
-    const con = timer.getContainer();
-    stage.addChild(con);
   };
 
   /**
@@ -179,6 +179,7 @@ const GameTestPage = (): JSX.Element => {
   function animate() {
     const mjGameState = gameState as MahjongGameState;
     mjGameState.renderCanvas(spriteFactory, pixiApplication);
+    mjGameState.update();
     forGameTesting();
     requestAnimationFrame(animate);
   }


### PR DESCRIPTION
- [x] Melds get rendered if player can make them. WS messages can be sent by clicking on them

- [x] Auto skip functionality when player cannot create meld.

- [x] Remove tiles from player hands when meld is created successfully

- [x] Implement timer to players to decide on creating meld or not, if not, automatically skip

- [x] Use Hand Validator to check if player can win (separate from CanCreateMeld) --> send PLAY_TILE_INTERACTION MeldTypes.WIN

Other functionalities that may be useful in this PR?

- [x] Check win condition when drawn, if true, render win button to send WIN_ROUND

Items below will be for next PR

- If season or flower is drawn, play flower/season and draw tile (May require a new lambda endpoint) // May also require players to check hands for these tiles before game starts.

- Self quad functionalities